### PR TITLE
fix: Replace LambdaTest brand name with TestMu AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run TestCafe Tests on TestMu AI (Formerly LambdaTest)
+﻿# Run TestCafe Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -10,7 +10,7 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can run TestCafe end-to-end browser tests across real browsers and operating systems. This sample shows how to configure TestCafe tests to run on the TestMu AI cloud using the LambdaTest browser provider plugin.
+With TestMu AI (Formerly LambdaTest), you can run TestCafe end-to-end browser tests across real browsers and operating systems. This sample shows how to configure TestCafe tests to run on the TestMu AI cloud using the TestMu AI (Formerly LambdaTest) browser provider plugin.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
@@ -24,7 +24,7 @@ With TestMu AI (Formerly LambdaTest), you can run TestCafe end-to-end browser te
 npm install -g testcafe
 ```
 
-- LambdaTest npm plugin for TestCafe:
+- TestMu AI (Formerly LambdaTest) npm plugin for TestCafe:
 
 ```bash
 npm install testcafe-browser-provider-lambdatest


### PR DESCRIPTION
Replaces all standalone LambdaTest brand mentions with TestMu AI (Formerly LambdaTest) in body text and TestMu AI in the H1 title. Code blocks, URLs, badge HTML, and boilerplate are untouched.