### PR TITLE
fix: update README branding and remove non-template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Run TestCafe Tests on TestMu AI (Formerly LambdaTest)
+# Run TestCafe Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,8 +17,8 @@ With TestMu AI (Formerly LambdaTest), you can run TestCafe end-to-end browser te
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/en/download/) (LTS version recommended) and npm
-- [TestCafe](https://devexpress.github.io/testcafe/) installed globally:
+- Node.js (LTS version recommended) and npm
+- TestCafe installed globally:
 
 ```bash
 npm install -g testcafe
@@ -30,7 +30,7 @@ npm install -g testcafe
 npm install testcafe-browser-provider-lambdatest
 ```
 
-- A TestMu AI (Formerly LambdaTest) account — [sign up here](https://www.testmuai.com/register/)
+- A TestMu AI (Formerly LambdaTest) account — sign up here
 
 ### Setup
 


### PR DESCRIPTION
- Replace standalone LambdaTest with TestMu AI (Formerly LambdaTest) in body text\n- Remove non-template links from Prerequisites/Setup/Run tests sections